### PR TITLE
Upgrades deps to Clojure-1.9 and Lucene-7.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,10 @@
   :url "https://github.com/structureddynamics/clj-fst"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.lucene/lucene-core "4.10.4"]
-                 [org.apache.lucene/lucene-misc "4.10.4"]
-                 [lein-marginalia "0.8.0"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.apache.lucene/lucene-core "7.3.1"]
+                 [org.apache.lucene/lucene-misc "7.3.1"]
+                 [lein-marginalia "0.9.1"]]
   :source-paths      ["src/clojure"]
   :java-source-paths ["src/java"]
   :target-path "target/%s"


### PR DESCRIPTION
Would like to suggest following changes-

* Upgrade ``Clojure`` to ``1.9``
* Upgrade ``Lucene`` to ``7.3.1``
* Upgrade ``lein-marginalia`` to ``0.9.1``
* Option to pack FST and specify overhead ratio is no longer support. So, dropped it.
* Used ``BytesRefBuilder`` instead of ``copyChars`` function that is deprecated and no-longer supported
* Use ``Path`` instead of Java ``File`` to save and load FSTs in Lucene 7.x